### PR TITLE
ci: update fortify/3rdparty-actions

### DIFF
--- a/.github/workflows/build-dev-release.yml
+++ b/.github/workflows/build-dev-release.yml
@@ -42,7 +42,7 @@ jobs:
           path: ${{ env.DIST_DIR }}
           
       - name: Update development release tag
-        uses: richardsimko/update-tag@v1
+        uses: fortify/3rdparty-actions/actions/richardsimko/update-tag/v1@main
         if: env.DO_RELEASE
         with:
           tag_name: ${{ env.RELEASE_TAG }}

--- a/.github/workflows/build-dev-release.yml
+++ b/.github/workflows/build-dev-release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check-out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       
       - name: Define development release info
         if: startsWith(github.ref, 'refs/heads/')
@@ -36,13 +36,13 @@ jobs:
         
       - name: Publish build artifacts
         if: env.DO_BUILD
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v7
         with:
           name: build_artifacts
           path: ${{ env.DIST_DIR }}
           
       - name: Update development release tag
-        uses: fortify/3rdparty-actions/actions/richardsimko/update-tag/v1@main
+        uses: fortify/.github/.github/actions/update-tag@main
         if: env.DO_RELEASE
         with:
           tag_name: ${{ env.RELEASE_TAG }}

--- a/.github/workflows/build-prod-release.yml
+++ b/.github/workflows/build-prod-release.yml
@@ -15,14 +15,15 @@ jobs:
       pull-requests: write
     steps:
       - name: Check-out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       
       - name: Generate and process release PR
         id: release_please
         uses: fortify/3rdparty-actions/actions/googleapis/release-please-action/v5@main
         with:
           release-type: simple
-          package-name: ${{ github.event.repository.name }}
+          skip-github-release: true
+          target-branch: ${{ github.ref_name }}
           
       - name: Define production release info
         if: steps.release_please.outputs.release_created

--- a/.github/workflows/build-prod-release.yml
+++ b/.github/workflows/build-prod-release.yml
@@ -10,13 +10,16 @@ name: Build production release
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Check-out source code
         uses: actions/checkout@v2
       
       - name: Generate and process release PR
         id: release_please
-        uses: GoogleCloudPlatform/release-please-action@v2
+        uses: fortify/3rdparty-actions/actions/googleapis/release-please-action/v5@main
         with:
           release-type: simple
           package-name: ${{ github.event.repository.name }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,7 @@
+{
+  "changelog-sections": [
+    { "type": "feat", "section": "Features", "hidden": false },
+    { "type": "fix",  "section": "Bug Fixes", "hidden": false },
+    { "type": "api",  "section": "API changes", "hidden": false }
+  ]
+}


### PR DESCRIPTION
Update supported workflow actions to use the shared fortify/3rdparty-actions wrappers.
also updated GoogleCloudPlatform/release-please-action to use googleapis/release-please-action@v5